### PR TITLE
feat: deprecate supportsDatabaseNames and getDatabaseNames which are …

### DIFF
--- a/idb_shim/lib/idb.dart
+++ b/idb_shim/lib/idb.dart
@@ -634,11 +634,18 @@ abstract class IdbFactory {
   ///
   /// if getDatabaseNames can be called
   ///
+  /// No longer supported on modern browsers. Always returns false
+  @Deprecated('No longer supported, always returns false')
   bool get supportsDatabaseNames;
 
   ///
-  /// list of databases
+  /// list of database names (only available if supportsDatabaseNames returns
+  /// true).
   ///
+  /// No longer supported on modern browsers. Could be implemented on top of
+  /// `databases` once available or deprecated in the future...you'd better
+  /// not start using it for now.
+  @Deprecated('No longer supported')
   Future<List<String>> getDatabaseNames();
 
   /// Changed to true when a factory is created

--- a/idb_shim/lib/src/logger/logger_factory.dart
+++ b/idb_shim/lib/src/logger/logger_factory.dart
@@ -108,10 +108,12 @@ class IdbFactoryWrapperImpl extends IdbFactoryBase implements IdbFactoryLogger {
 
   @override
   bool get supportsDatabaseNames {
+    // ignore: deprecated_member_use_from_same_package
     return nativeFactory.supportsDatabaseNames;
   }
 
   @override
+  // ignore: deprecated_member_use_from_same_package
   Future<List<String>> getDatabaseNames() => nativeFactory.getDatabaseNames();
 
   @override

--- a/idb_shim/lib/src/native/native_factory.dart
+++ b/idb_shim/lib/src/native/native_factory.dart
@@ -100,7 +100,8 @@ class IdbFactoryNativeWrapperImpl extends IdbFactoryBase {
 
   @override
   bool get supportsDatabaseNames {
-    return nativeFactory.supportsDatabaseNames;
+    // No longer supported on modern browsers. Always returns false
+    return false;
   }
 
   @override

--- a/idb_test/lib/factory_test.dart
+++ b/idb_test/lib/factory_test.dart
@@ -89,11 +89,14 @@ void defineTests(TestContext ctx) {
     }, testOn: 'js');
     */
 
+    // ignore: deprecated_member_use
     if (idbFactory!.supportsDatabaseNames) {
       test('supportsDatabaseNames', () {
+        // ignore: deprecated_member_use
         expect(idbFactory.supportsDatabaseNames, true);
       });
       test('database names', () {
+        // ignore: deprecated_member_use
         return idbFactory.getDatabaseNames().then((List<String> names) {
           expect(names, isNotNull);
         });
@@ -118,6 +121,7 @@ void defineTests(TestContext ctx) {
           final db = await idbFactory.open(_dbName!);
           db.close();
 
+          // ignore: deprecated_member_use
           final names = await idbFactory.getDatabaseNames();
           expect(names, contains(_dbName));
         });
@@ -126,10 +130,11 @@ void defineTests(TestContext ctx) {
           await _setupDeleteDb();
           final db = await idbFactory.open(_dbName!);
           db.close();
-
+          // ignore: deprecated_member_use
           var names = await idbFactory.getDatabaseNames();
           expect(names, contains(_dbName));
           await idbFactory.deleteDatabase(_dbName!);
+          // ignore: deprecated_member_use
           names = await idbFactory.getDatabaseNames();
           expect(names, isNot(contains(_dbName)));
         });
@@ -141,7 +146,7 @@ void defineTests(TestContext ctx) {
           await idbFactory.deleteDatabase(dbName2);
           (await idbFactory.open(dbName1)).close();
           (await idbFactory.open(dbName2)).close();
-
+          // ignore: deprecated_member_use
           final names = await idbFactory.getDatabaseNames();
           expect(names, contains(dbName1));
           expect(names, contains(dbName2));
@@ -155,11 +160,13 @@ void defineTests(TestContext ctx) {
           (await idbFactory.open(dbName1)).close();
           (await idbFactory.open(dbName2)).close();
 
+          // ignore: deprecated_member_use
           var names = await idbFactory.getDatabaseNames();
           final length = names.length;
           expect(names, contains(dbName1));
           expect(names, contains(dbName2));
 
+          // ignore: deprecated_member_use
           names = await idbFactory.getDatabaseNames();
           expect(names.length, length);
         });

--- a/idb_test/lib/indexeddb_1_test.dart
+++ b/idb_test/lib/indexeddb_1_test.dart
@@ -194,6 +194,7 @@ void defineTests(TestContext ctx) {
 
   group('supportsDatabaseNames', () {
     test('supported', () {
+      // ignore: deprecated_member_use
       expect(idbFactory!.supportsDatabaseNames, isTrue);
     });
   }, skip: true);

--- a/idb_test/lib/indexeddb_5_test.dart
+++ b/idb_test/lib/indexeddb_5_test.dart
@@ -41,8 +41,10 @@ void defineTests(TestContext ctx) {
       db.close();
     });
 
+    // ignore: deprecated_member_use
     if (idbFactory!.supportsDatabaseNames) {
       test('getDatabaseNames', () {
+        // ignore: deprecated_member_use
         return idbFactory.getDatabaseNames().then((names) {
           //print(names);
           //print(dbName);


### PR DESCRIPTION
…no longer supported (and not implemented before)